### PR TITLE
errors in the login_company_flow test cases are corrected

### DIFF
--- a/resources/android/variables/variables.robot
+++ b/resources/android/variables/variables.robot
@@ -16,10 +16,10 @@ ${NAME_COMPANY}          Empresa pruebas
 ${NAME_NOEXIST}          Ram
 
 # Continua Con Empresa Locators
-${LOGIN_SUBMIT_CONTINUACONEMPRESA}    //android.widget.Button[@content-desc="Continúa con tu empresa"]
+${LOGIN_SUBMIT_CONTINUACONEMPRESA}   //android.widget.Button[@content-desc="Continúa con tu empresa"]
 ${LOGIN_COMPANY_FIELD}               //android.widget.EditText
 ${LOGIN_SUBMIT_BUTTON_CONTINUAR}     //android.widget.Button[@content-desc="Continuar"]
-${COMPANY_SELECTOR}                  Empresa pruebas    # accessibility_id para la empresa
+${COMPANY_SELECTOR}                  //android.widget.ImageView[@content-desc="Empresa pruebas"]
 ${EMAIL_FIELD}                       //android.widget.EditText  # Localizador para el campo de correo
 ${NUMBER_FIELD}                      //android.widget.EditText
 ${VERIFY_BUTTON}                     //android.widget.Button[@content-desc="Verificar"]

--- a/tests/login_company_flow.robot
+++ b/tests/login_company_flow.robot
@@ -9,6 +9,7 @@ Suite Setup     Setting timeouts
 *** Test Cases ***
 Validation error message when not choosing a company
     Open 1doc3 Application
+    Wait Until Element Is Visible    ${LOGIN_SUBMIT_CONTINUACONEMPRESA}
     Click Element    ${LOGIN_SUBMIT_CONTINUACONEMPRESA}
     Input Text       ${LOGIN_COMPANY_FIELD}    ${NAME_COMPANY}
     Click Element    ${LOGIN_SUBMIT_BUTTON_CONTINUAR}
@@ -19,15 +20,17 @@ Validation error message when not choosing a company
 
 Error validation when deleting company name
     Open 1doc3 Application
+    Wait Until Element Is Visible   ${LOGIN_SUBMIT_CONTINUACONEMPRESA}
     Click Element    ${LOGIN_SUBMIT_CONTINUACONEMPRESA}
     Input Text       ${LOGIN_COMPANY_FIELD}    ${NAME_COMPANY}
-    Clear Text       ${NAME_COMPANY}
+    Clear Text       ${LOGIN_COMPANY_FIELD}
     Click Element    ${LOGIN_SUBMIT_BUTTON_CONTINUAR}
     Wait Until Element is visible    ${ERROR_WRITING_COMPANY}
     Close Application
 
 Validation of non-existent company
     Open 1doc3 Application
+    Wait Until Element Is Visible   ${LOGIN_SUBMIT_CONTINUACONEMPRESA}
     Click Element    ${LOGIN_SUBMIT_CONTINUACONEMPRESA}
     Input Text       ${LOGIN_COMPANY_FIELD}    ${NAME_NOEXIST}
     Wait Until Element is visible    ${ERROR_NO_COMPANY_EXISTS}
@@ -35,8 +38,10 @@ Validation of non-existent company
 
 Validation input verification data
     Open 1doc3 Application 
+    Wait Until Element Is Visible   ${LOGIN_SUBMIT_CONTINUACONEMPRESA}
     Click Element    ${LOGIN_SUBMIT_CONTINUACONEMPRESA}
     Input Text       ${LOGIN_COMPANY_FIELD}    ${NAME_COMPANY}
+    Wait Until Element Is Visible   ${COMPANY_SELECTOR}
     Click Element    ${COMPANY_SELECTOR}
     Click Element    ${LOGIN_SUBMIT_BUTTON_CONTINUAR}
     Verify Text on Element    ${PAGE_VERIFY_USER}    ${VERIFY_DATO_EMAIL}


### PR DESCRIPTION
What I did:
I added a keyword to wait for elements before using them and I corrected an identifier of a test case that was sending wrong.

Why I did it:
When running the test, an error always came up even though the locators were correctly referenced. Using the keyword I added allows you to wait to find them to avoid the error that always came up. And the test case that had the wrong locator was sending the wrong one, which is why it never found it.

How I tested it:
I ran the test cases again and they all remained in Done status.